### PR TITLE
Rename `CTAssetPickerController` class

### DIFF
--- a/CTAssetsPicker/CTAssetsPicker.h
+++ b/CTAssetsPicker/CTAssetsPicker.h
@@ -37,7 +37,7 @@ FOUNDATION_EXPORT const unsigned char CTAssetsPickerVersionString[];
 #import <CTAssetsPicker/CTAssetsPageView.h>
 #import <CTAssetsPicker/CTAssetsPageViewController.h>
 #import <CTAssetsPicker/CTAssetsPickerAccessDeniedView.h>
-#import <CTAssetsPicker/CTAssetsPickerController.h>
+#import <CTAssetsPicker/CTAssetsPickerViewController.h>
 #import <CTAssetsPicker/CTAssetsPickerDefines.h>
 #import <CTAssetsPicker/CTAssetsPickerNoAssetsView.h>
 #import <CTAssetsPicker/CTAssetsViewControllerTransition.h>

--- a/CTAssetsPickerController/CTAssetCollectionViewController.m
+++ b/CTAssetsPickerController/CTAssetCollectionViewController.m
@@ -25,8 +25,8 @@
  */
 
 #import "CTAssetsPickerDefines.h"
-#import "CTAssetsPickerController.h"
-#import "CTAssetsPickerController+Internal.h"
+#import "CTAssetsPickerViewController.h"
+#import "CTAssetsPickerViewController+Internal.h"
 #import "CTAssetCollectionViewController.h"
 #import "CTAssetCollectionViewCell.h"
 #import "CTAssetsGridViewController.h"
@@ -42,7 +42,7 @@
 @interface CTAssetCollectionViewController()
 <PHPhotoLibraryChangeObserver, CTAssetsGridViewControllerDelegate>
 
-@property (nonatomic, weak) CTAssetsPickerController *picker;
+@property (nonatomic, weak) CTAssetsPickerViewController *picker;
 
 @property (nonatomic, strong) UIBarButtonItem *cancelButton;
 @property (nonatomic, strong) UIBarButtonItem *doneButton;
@@ -114,9 +114,9 @@
 
 #pragma mark - Accessors
 
-- (CTAssetsPickerController *)picker
+- (CTAssetsPickerViewController *)picker
 {
-    return (CTAssetsPickerController *)self.splitViewController.parentViewController;
+    return (CTAssetsPickerViewController *)self.splitViewController.parentViewController;
 }
 
 - (NSIndexPath *)indexPathForAssetCollection:(PHAssetCollection *)assetCollection

--- a/CTAssetsPickerController/CTAssetItemViewController.m
+++ b/CTAssetsPickerController/CTAssetItemViewController.m
@@ -26,7 +26,7 @@
 
 
 @import PureLayout;
-#import "CTAssetsPickerController.h"
+#import "CTAssetsPickerViewController.h"
 #import "CTAssetItemViewController.h"
 #import "CTAssetScrollView.h"
 #import "NSBundle+CTAssetsPickerController.h"
@@ -38,7 +38,7 @@
 
 @interface CTAssetItemViewController ()
 
-@property (nonatomic, weak) CTAssetsPickerController *picker;
+@property (nonatomic, weak) CTAssetsPickerViewController *picker;
 
 @property (nonatomic, strong) PHAsset *asset;
 @property (nonatomic, strong) UIImage *image;
@@ -116,9 +116,9 @@
 
 #pragma mark - Accessors
 
-- (CTAssetsPickerController *)picker
+- (CTAssetsPickerViewController *)picker
 {
-    return (CTAssetsPickerController *)self.splitViewController.parentViewController;
+    return (CTAssetsPickerViewController *)self.splitViewController.parentViewController;
 }
 
 

--- a/CTAssetsPickerController/CTAssetsGridViewController.m
+++ b/CTAssetsPickerController/CTAssetsGridViewController.m
@@ -25,8 +25,8 @@
  */
 
 #import "CTAssetsPickerDefines.h"
-#import "CTAssetsPickerController.h"
-#import "CTAssetsPickerController+Internal.h"
+#import "CTAssetsPickerViewController.h"
+#import "CTAssetsPickerViewController+Internal.h"
 #import "CTAssetsGridViewController.h"
 #import "CTAssetsGridView.h"
 #import "CTAssetsGridViewLayout.h"
@@ -52,7 +52,7 @@ NSString * const CTAssetsGridViewFooterIdentifier = @"CTAssetsGridViewFooterIden
 @interface CTAssetsGridViewController ()
 <PHPhotoLibraryChangeObserver>
 
-@property (nonatomic, weak) CTAssetsPickerController *picker;
+@property (nonatomic, weak) CTAssetsPickerViewController *picker;
 @property (nonatomic, strong) PHFetchResult *fetchResult;
 @property (nonatomic, strong) PHCachingImageManager *imageManager;
 
@@ -154,9 +154,9 @@ NSString * const CTAssetsGridViewFooterIdentifier = @"CTAssetsGridViewFooterIden
 
 #pragma mark - Accessors
 
-- (CTAssetsPickerController *)picker
+- (CTAssetsPickerViewController *)picker
 {
-    return (CTAssetsPickerController *)self.splitViewController.parentViewController;
+    return (CTAssetsPickerViewController *)self.splitViewController.parentViewController;
 }
 
 - (PHAsset *)assetAtIndexPath:(NSIndexPath *)indexPath

--- a/CTAssetsPickerController/CTAssetsPageViewController+Internal.h
+++ b/CTAssetsPickerController/CTAssetsPageViewController+Internal.h
@@ -24,6 +24,8 @@
  
  */
 
+#import "CTAssetsPageViewController.h"
+
 @interface CTAssetsPageViewController (Internal)
 
 @property (nonatomic, assign) BOOL allowsSelection;

--- a/CTAssetsPickerController/CTAssetsPageViewController.h
+++ b/CTAssetsPickerController/CTAssetsPageViewController.h
@@ -26,7 +26,6 @@
 
 #import <UIKit/UIKit.h>
 #import <Photos/Photos.h>
-#import "CTAssetsPageViewController.h"
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/CTAssetsPickerController/CTAssetsPageViewController.h
+++ b/CTAssetsPickerController/CTAssetsPageViewController.h
@@ -26,7 +26,7 @@
 
 #import <UIKit/UIKit.h>
 #import <Photos/Photos.h>
-
+#import "CTAssetsPageViewController.h"
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/CTAssetsPickerController/CTAssetsPickerViewController+Internal.h
+++ b/CTAssetsPickerController/CTAssetsPickerViewController+Internal.h
@@ -24,7 +24,7 @@
  
  */
 
-@interface CTAssetsPickerController (Internal)
+@interface CTAssetsPickerViewController (Internal)
 
 - (void)dismiss:(id)sender;
 - (void)finishPickingAssets:(id)sender;

--- a/CTAssetsPickerController/CTAssetsPickerViewController+Internal.h
+++ b/CTAssetsPickerController/CTAssetsPickerViewController+Internal.h
@@ -24,6 +24,8 @@
  
  */
 
+#import "CTAssetsPickerViewController.h"
+
 @interface CTAssetsPickerViewController (Internal)
 
 - (void)dismiss:(id)sender;

--- a/CTAssetsPickerController/CTAssetsPickerViewController.h
+++ b/CTAssetsPickerController/CTAssetsPickerViewController.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  A controller that allows picking multiple photos and videos from user's photo library.
  */
-@interface CTAssetsPickerController : UIViewController
+@interface CTAssetsPickerViewController : UIViewController
 
 /**
  *  The assets picker’s delegate object.
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The delegate methods are responsible for dismissing the picker when the operation completes.
  *  To dismiss the picker, call the `dismissViewControllerAnimated:completion:` method of the presenting controller
- *  responsible for displaying `CTAssetsPickerController` object.
+ *  responsible for displaying `CTAssetsPickerViewController` object.
  *
  *  The picked assets are `PHAsset` objects and contain only metadata. The underlying image or video data for any given asset might not be stored on the local device.
  *  You have to use `PHImageManager` object for loading image or video data associated with a `PHAsset`.
@@ -196,7 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see assetsPickerControllerDidCancel:
  */
-- (void)assetsPickerController:(CTAssetsPickerController *)picker didFinishPickingAssets:(NSArray<PHAsset*> *)assets;
+- (void)assetsPickerController:(CTAssetsPickerViewController *)picker didFinishPickingAssets:(NSArray<PHAsset*> *)assets;
 
 @optional
 
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see assetsPickerController:didFinishPickingAssets:
  */
-- (void)assetsPickerControllerDidCancel:(CTAssetsPickerController *)picker;
+- (void)assetsPickerControllerDidCancel:(CTAssetsPickerViewController *)picker;
 
 
 /**
@@ -223,7 +223,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return Custom `UICollectionViewLayout` for the asset selection view.
  */
-- (UICollectionViewLayout *)assetsPickerController:(CTAssetsPickerController *)picker collectionViewLayoutForContentSize:(CGSize)contentSize traitCollection:(UITraitCollection *)trait;
+- (UICollectionViewLayout *)assetsPickerController:(CTAssetsPickerViewController *)picker collectionViewLayoutForContentSize:(CGSize)contentSize traitCollection:(UITraitCollection *)trait;
 
 
 /**
@@ -235,7 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return `YES` (the default) if the asset grid should scroll to bottom on shown or `NO` if it should not.
  */
 
-- (BOOL)assetsPickerController:(CTAssetsPickerController *)picker shouldScrollToBottomForAssetCollection:(PHAssetCollection *)assetCollection;
+- (BOOL)assetsPickerController:(CTAssetsPickerViewController *)picker shouldScrollToBottomForAssetCollection:(PHAssetCollection *)assetCollection;
 
 
 /**
@@ -252,7 +252,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see assetsPickerController:shouldShowAsset:
  */
-- (BOOL)assetsPickerController:(CTAssetsPickerController *)picker shouldEnableAsset:(PHAsset *)asset;
+- (BOOL)assetsPickerController:(CTAssetsPickerViewController *)picker shouldEnableAsset:(PHAsset *)asset;
 
 
 /**
@@ -269,7 +269,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see assetsPickerController:shouldDeselectAsset:
  */
-- (BOOL)assetsPickerController:(CTAssetsPickerController *)picker shouldSelectAsset:(PHAsset *)asset;
+- (BOOL)assetsPickerController:(CTAssetsPickerViewController *)picker shouldSelectAsset:(PHAsset *)asset;
 
 /**
  *  Tells the delegate that the asset was selected.
@@ -279,7 +279,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see assetsPickerController:didDeselectAsset:
  */
-- (void)assetsPickerController:(CTAssetsPickerController *)picker didSelectAsset:(PHAsset *)asset;
+- (void)assetsPickerController:(CTAssetsPickerViewController *)picker didSelectAsset:(PHAsset *)asset;
 
 /**
  *  Asks the delegate if the specified asset should be deselected.
@@ -291,7 +291,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see assetsPickerController:shouldSelectAsset:
  */
-- (BOOL)assetsPickerController:(CTAssetsPickerController *)picker shouldDeselectAsset:(PHAsset *)asset;
+- (BOOL)assetsPickerController:(CTAssetsPickerViewController *)picker shouldDeselectAsset:(PHAsset *)asset;
 
 /**
  *  Tells the delegate that the item at the specified path was deselected.
@@ -301,7 +301,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see assetsPickerController:didSelectAsset:
  */
-- (void)assetsPickerController:(CTAssetsPickerController *)picker didDeselectAsset:(PHAsset *)asset;
+- (void)assetsPickerController:(CTAssetsPickerViewController *)picker didDeselectAsset:(PHAsset *)asset;
 
 
 
@@ -317,7 +317,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return `YES` if the asset should be highlighted or `NO` if it should not.
  */
-- (BOOL)assetsPickerController:(CTAssetsPickerController *)picker shouldHighlightAsset:(PHAsset *)asset;
+- (BOOL)assetsPickerController:(CTAssetsPickerViewController *)picker shouldHighlightAsset:(PHAsset *)asset;
 
 /**
  *  Tells the delegate that asset was highlighted.
@@ -327,7 +327,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see assetsPickerController:didUnhighlightAsset:
  */
-- (void)assetsPickerController:(CTAssetsPickerController *)picker didHighlightAsset:(PHAsset *)asset;
+- (void)assetsPickerController:(CTAssetsPickerViewController *)picker didHighlightAsset:(PHAsset *)asset;
 
 
 /**
@@ -338,7 +338,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see assetsPickerController:didHighlightAsset:
  */
-- (void)assetsPickerController:(CTAssetsPickerController *)picker didUnhighlightAsset:(PHAsset *)asset;
+- (void)assetsPickerController:(CTAssetsPickerViewController *)picker didUnhighlightAsset:(PHAsset *)asset;
 
 
 

--- a/CTAssetsPickerController/CTAssetsPickerViewController.m
+++ b/CTAssetsPickerController/CTAssetsPickerViewController.m
@@ -26,7 +26,7 @@
 
 
 #import "CTAssetsPickerDefines.h"
-#import "CTAssetsPickerController.h"
+#import "CTAssetsPickerViewController.h"
 #import "CTAssetsPickerAccessDeniedView.h"
 #import "CTAssetsPickerNoAssetsView.h"
 #import "CTAssetCollectionViewController.h"
@@ -47,7 +47,7 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
 
 
 
-@interface CTAssetsPickerController ()
+@interface CTAssetsPickerViewController ()
 <PHPhotoLibraryChangeObserver, UISplitViewControllerDelegate, UINavigationControllerDelegate>
 
 @property (nonatomic, assign) BOOL shouldCollapseDetailViewController;
@@ -61,7 +61,7 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
 
 
 
-@implementation CTAssetsPickerController
+@implementation CTAssetsPickerViewController
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {

--- a/CTAssetsPickerController/NSBundle+CTAssetsPickerController.m
+++ b/CTAssetsPickerController/NSBundle+CTAssetsPickerController.m
@@ -25,13 +25,13 @@
  */
 
 #import "NSBundle+CTAssetsPickerController.h"
-#import "CTAssetsPickerController.h"
+#import "CTAssetsPickerViewController.h"
 
 @implementation NSBundle (CTAssetsPickerController)
 
 + (NSBundle *)ctassetsPickerBundle
 {
-    return [NSBundle bundleForClass:[CTAssetsPickerController class]];
+    return SWIFTPM_MODULE_BUNDLE;
 }
 
 

--- a/CTAssetsPickerController/Resources/CTAssetsPicker.xcassets/BadgeSloMoSmall.imageset/Contents.json
+++ b/CTAssetsPickerController/Resources/CTAssetsPicker.xcassets/BadgeSloMoSmall.imageset/Contents.json
@@ -1,23 +1,23 @@
 {
   "images" : [
     {
+      "filename" : "BadgeSloMoSmall.png",
       "idiom" : "universal",
-      "filename" : "BadgeSlomoSmall.png",
       "scale" : "1x"
     },
     {
+      "filename" : "BadgeSloMoSmall@2x.png",
       "idiom" : "universal",
-      "filename" : "BadgeSlomoSmall@2x.png",
       "scale" : "2x"
     },
     {
+      "filename" : "BadgeSloMoSmall@3x.png",
       "idiom" : "universal",
-      "filename" : "BadgeSlomoSmall@3x.png",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/CTAssetsPickerController/UIImage+CTAssetsPickerController.m
+++ b/CTAssetsPickerController/UIImage+CTAssetsPickerController.m
@@ -24,7 +24,7 @@
  
  */
 
-#import "CTAssetsPickerController.h"
+#import "CTAssetsPickerViewController.h"
 #import "UIImage+CTAssetsPickerController.h"
 #import "NSBundle+CTAssetsPickerController.h"
 

--- a/CTAssetsPickerDemo/CTMasterViewController.m
+++ b/CTAssetsPickerDemo/CTMasterViewController.m
@@ -24,7 +24,7 @@
  
  */
 
-#import <CTAssetsPickerController/CTAssetsPickerController.h>
+#import <CTAssetsPickerController/CTAssetsPickerViewController.h>
 #import "CTMasterViewController.h"
 
 #import "CTBasicViewController.h"

--- a/CTAssetsPickerDemo/Examples/CTApperanceViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTApperanceViewController.m
@@ -64,7 +64,7 @@
     self.font   = [UIFont fontWithName:@"Futura-Medium" size:22.0];
 
     // Navigation Bar apperance
-    UINavigationBar *navBar = [UINavigationBar appearanceWhenContainedIn:[CTAssetsPickerController class], nil];
+    UINavigationBar *navBar = [UINavigationBar appearanceWhenContainedIn:[CTAssetsPickerViewController class], nil];
     
     // set nav bar style to black to force light content status bar style
     navBar.barStyle = UIBarStyleBlack;
@@ -81,12 +81,12 @@
       NSFontAttributeName : self.font};
     
     // bar button item appearance
-    UIBarButtonItem *barButtonItem = [UIBarButtonItem appearanceWhenContainedIn:[CTAssetsPickerController class], nil];
+    UIBarButtonItem *barButtonItem = [UIBarButtonItem appearanceWhenContainedIn:[CTAssetsPickerViewController class], nil];
     [barButtonItem setTitleTextAttributes:@{NSFontAttributeName : [self.font fontWithSize:18.0]}
                                  forState:UIControlStateNormal];
     
     // albums view
-    UITableView *assetCollectionView = [UITableView appearanceWhenContainedIn:[CTAssetsPickerController class], nil];
+    UITableView *assetCollectionView = [UITableView appearanceWhenContainedIn:[CTAssetsPickerViewController class], nil];
     assetCollectionView.backgroundColor = self.color2;
     
     // asset collection appearance
@@ -143,7 +143,7 @@
     assetsPageView.fullscreenBackgroundColor = self.color2;
     
     // progress view
-    [UIProgressView appearanceWhenContainedIn:[CTAssetsPickerController class], nil].tintColor = self.color1;
+    [UIProgressView appearanceWhenContainedIn:[CTAssetsPickerViewController class], nil].tintColor = self.color1;
     
 }
 
@@ -151,7 +151,7 @@
 {
     // reset appearance
     // for demo purpose. it is not necessary to reset appearance in real case.
-    UINavigationBar *navBar = [UINavigationBar appearanceWhenContainedIn:[CTAssetsPickerController class], nil];
+    UINavigationBar *navBar = [UINavigationBar appearanceWhenContainedIn:[CTAssetsPickerViewController class], nil];
     
     navBar.barStyle = UIBarStyleDefault;
     
@@ -161,11 +161,11 @@
     
     navBar.titleTextAttributes = nil;
     
-    UIBarButtonItem *barButtonItem = [UIBarButtonItem appearanceWhenContainedIn:[CTAssetsPickerController class], nil];
+    UIBarButtonItem *barButtonItem = [UIBarButtonItem appearanceWhenContainedIn:[CTAssetsPickerViewController class], nil];
     [barButtonItem setTitleTextAttributes:nil
                                       forState:UIControlStateNormal];
     
-    UITableView *assetCollectionView = [UITableView appearanceWhenContainedIn:[CTAssetsPickerController class], nil];
+    UITableView *assetCollectionView = [UITableView appearanceWhenContainedIn:[CTAssetsPickerViewController class], nil];
     assetCollectionView.backgroundColor = [UIColor whiteColor];
     
     CTAssetCollectionViewCell *assetCollectionViewCell = [CTAssetCollectionViewCell appearance];
@@ -211,7 +211,7 @@
     assetsPageView.pageBackgroundColor = nil;
     assetsPageView.fullscreenBackgroundColor = nil;
     
-    [UIProgressView appearanceWhenContainedIn:[CTAssetsPickerController class], nil].tintColor = nil;
+    [UIProgressView appearanceWhenContainedIn:[CTAssetsPickerViewController class], nil].tintColor = nil;
 }
 
 
@@ -221,7 +221,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;

--- a/CTAssetsPickerDemo/Examples/CTBasicViewController.h
+++ b/CTAssetsPickerDemo/Examples/CTBasicViewController.h
@@ -25,7 +25,7 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <CTAssetsPickerController/CTAssetsPickerController.h>
+#import <CTAssetsPickerController/CTAssetsPickerViewController.h>
 #import <CTAssetsPickerController/CTAssetsPageViewController.h>
 
 @interface CTBasicViewController : UITableViewController

--- a/CTAssetsPickerDemo/Examples/CTBasicViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTBasicViewController.m
@@ -94,7 +94,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
 
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;
@@ -163,7 +163,7 @@
 
 #pragma mark - Assets Picker Delegate
 
-- (void)assetsPickerController:(CTAssetsPickerController *)picker didFinishPickingAssets:(NSArray *)assets
+- (void)assetsPickerController:(CTAssetsPickerViewController *)picker didFinishPickingAssets:(NSArray *)assets
 {
     [picker dismissViewControllerAnimated:YES completion:nil];
 

--- a/CTAssetsPickerDemo/Examples/CTDefaultAlbumViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTDefaultAlbumViewController.m
@@ -35,7 +35,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;

--- a/CTAssetsPickerDemo/Examples/CTLastWeekViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTLastWeekViewController.m
@@ -35,7 +35,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;

--- a/CTAssetsPickerDemo/Examples/CTLayoutViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTLayoutViewController.m
@@ -29,7 +29,7 @@
 
 @implementation CTLayoutViewController
 
-- (UICollectionViewLayout *)assetsPickerController:(CTAssetsPickerController *)picker collectionViewLayoutForContentSize:(CGSize)contentSize traitCollection:(UITraitCollection *)trait
+- (UICollectionViewLayout *)assetsPickerController:(CTAssetsPickerViewController *)picker collectionViewLayoutForContentSize:(CGSize)contentSize traitCollection:(UITraitCollection *)trait
 {
     UICollectionViewFlowLayout *layout = [UICollectionViewFlowLayout new];
     layout.itemSize = CGSizeMake(175, 175);

--- a/CTAssetsPickerDemo/Examples/CTMaxSelectionViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTMaxSelectionViewController.m
@@ -35,7 +35,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;
@@ -52,7 +52,7 @@
 }
 
 // implement should select asset delegate
-- (BOOL)assetsPickerController:(CTAssetsPickerController *)picker shouldSelectAsset:(PHAsset *)asset
+- (BOOL)assetsPickerController:(CTAssetsPickerViewController *)picker shouldSelectAsset:(PHAsset *)asset
 {
     NSInteger max = 3;
     

--- a/CTAssetsPickerDemo/Examples/CTPhotosViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTPhotosViewController.m
@@ -35,7 +35,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;

--- a/CTAssetsPickerDemo/Examples/CTProgrammaticViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTProgrammaticViewController.m
@@ -89,7 +89,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;
@@ -113,7 +113,7 @@
     }];
 }
 
-- (void)selectAssetsForAssetsPickertController:(CTAssetsPickerController *)picker
+- (void)selectAssetsForAssetsPickertController:(CTAssetsPickerViewController *)picker
 {
     NSInteger count = 0;
     CGFloat pause = 1.0;

--- a/CTAssetsPickerDemo/Examples/CTSelectedAssetsViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTSelectedAssetsViewController.m
@@ -35,7 +35,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;

--- a/CTAssetsPickerDemo/Examples/CTSelectionOrderViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTSelectionOrderViewController.m
@@ -55,7 +55,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;

--- a/CTAssetsPickerDemo/Examples/CTSloMoViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTSloMoViewController.m
@@ -35,7 +35,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;

--- a/CTAssetsPickerDemo/Examples/CTSortedAssetsViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTSortedAssetsViewController.m
@@ -35,7 +35,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;
@@ -59,7 +59,7 @@
 }
 
 
-- (BOOL)assetsPickerController:(CTAssetsPickerController *)picker shouldScrollToBottomForAssetCollection:(PHAssetCollection *)assetCollection
+- (BOOL)assetsPickerController:(CTAssetsPickerViewController *)picker shouldScrollToBottomForAssetCollection:(PHAssetCollection *)assetCollection
 {
     // As assets are sorted by date and latest assets are on top of grid view,
     // we do not scroll the asset grid view to the bottom on shown.

--- a/CTAssetsPickerDemo/Examples/CTUITweaksViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTUITweaksViewController.m
@@ -35,7 +35,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;

--- a/CTAssetsPickerDemo/Examples/CTiCloudAlbumsViewController.m
+++ b/CTAssetsPickerDemo/Examples/CTiCloudAlbumsViewController.m
@@ -35,7 +35,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             
             // init picker
-            CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
+            CTAssetsPickerViewController *picker = [[CTAssetsPickerViewController alloc] init];
             
             // set delegate
             picker.delegate = self;

--- a/Package.swift
+++ b/Package.swift
@@ -7,14 +7,13 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [.iOS(.v13)],
     products: [
-        .library(name: "CTAssetsPickerController", targets: ["CTAssetsPickerControllerTarget"])
+        .library(name: "CTAssetsPickerController", targets: ["CTAssetsPickerController"])
     ],
     dependencies: [
         .package(name: "PureLayout", url: "https://github.com/PureLayout/PureLayout.git", .upToNextMajor(from: "3.1.6"))
     ],
     targets: [
-        // The target name is different so that Xcode doesn't think CTAssetsPickerController.h is supposed to be an umbrella header.
-        .target(name: "CTAssetsPickerControllerTarget",
+        .target(name: "CTAssetsPickerController",
                 dependencies: ["PureLayout"],
                 path: "CTAssetsPickerController",
                 resources: [

--- a/Package.swift
+++ b/Package.swift
@@ -7,15 +7,19 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [.iOS(.v13)],
     products: [
-        .library(name: "CTAssetsPickerController", targets: ["CTAssetsPickerController"])
+        .library(name: "CTAssetsPickerController", targets: ["CTAssetsPickerControllerTarget"])
     ],
     dependencies: [
         .package(name: "PureLayout", url: "https://github.com/PureLayout/PureLayout.git", .upToNextMajor(from: "3.1.6"))
     ],
     targets: [
-        .target(name: "CTAssetsPickerController",
+        // The target name is different so that Xcode doesn't think CTAssetsPickerController.h is supposed to be an umbrella header.
+        .target(name: "CTAssetsPickerControllerTarget",
                 dependencies: ["PureLayout"],
                 path: "CTAssetsPickerController",
+                resources: [
+                    .process("Resources")
+                ],
                 publicHeadersPath: "")
     ]
 )


### PR DESCRIPTION
This is another way of fixing the SPM issue in Xcode 12.5 that is described in PR #4.

Xcode seems to think that a header file with the same name as the target must be an umbrella header. I renamed the `CTAssetsPickerController` class so that Xcode won't get confused.

In addition, I updated the `NSBundle+CTAssetsPickerController` category so that it uses `SWIFTPM_MODULE_BUNDLE`. This will fix the issue of missing images in the photo picker.