### PR TITLE
Add `include` directory for public headers

### DIFF
--- a/CTAssetsPickerController/NSBundle+CTAssetsPickerController.m
+++ b/CTAssetsPickerController/NSBundle+CTAssetsPickerController.m
@@ -31,7 +31,7 @@
 
 + (NSBundle *)ctassetsPickerBundle
 {
-    return [NSBundle bundleForClass:[CTAssetsPickerController class]];
+    return SWIFTPM_MODULE_BUNDLE;
 }
 
 

--- a/CTAssetsPickerController/include/CTAssetCheckmark.h
+++ b/CTAssetsPickerController/include/CTAssetCheckmark.h
@@ -1,0 +1,1 @@
+../CTAssetCheckmark.h

--- a/CTAssetsPickerController/include/CTAssetCollectionViewCell.h
+++ b/CTAssetsPickerController/include/CTAssetCollectionViewCell.h
@@ -1,0 +1,1 @@
+../CTAssetCollectionViewCell.h

--- a/CTAssetsPickerController/include/CTAssetCollectionViewController.h
+++ b/CTAssetsPickerController/include/CTAssetCollectionViewController.h
@@ -1,0 +1,1 @@
+../CTAssetCollectionViewController.h

--- a/CTAssetsPickerController/include/CTAssetItemViewController.h
+++ b/CTAssetsPickerController/include/CTAssetItemViewController.h
@@ -1,0 +1,1 @@
+../CTAssetItemViewController.h

--- a/CTAssetsPickerController/include/CTAssetPlayButton.h
+++ b/CTAssetsPickerController/include/CTAssetPlayButton.h
@@ -1,0 +1,1 @@
+../CTAssetPlayButton.h

--- a/CTAssetsPickerController/include/CTAssetScrollView.h
+++ b/CTAssetsPickerController/include/CTAssetScrollView.h
@@ -1,0 +1,1 @@
+../CTAssetScrollView.h

--- a/CTAssetsPickerController/include/CTAssetSelectionButton.h
+++ b/CTAssetsPickerController/include/CTAssetSelectionButton.h
@@ -1,0 +1,1 @@
+../CTAssetSelectionButton.h

--- a/CTAssetsPickerController/include/CTAssetSelectionLabel.h
+++ b/CTAssetsPickerController/include/CTAssetSelectionLabel.h
@@ -1,0 +1,1 @@
+../CTAssetSelectionLabel.h

--- a/CTAssetsPickerController/include/CTAssetThumbnailOverlay.h
+++ b/CTAssetsPickerController/include/CTAssetThumbnailOverlay.h
@@ -1,0 +1,1 @@
+../CTAssetThumbnailOverlay.h

--- a/CTAssetsPickerController/include/CTAssetThumbnailStacks.h
+++ b/CTAssetsPickerController/include/CTAssetThumbnailStacks.h
@@ -1,0 +1,1 @@
+../CTAssetThumbnailStacks.h

--- a/CTAssetsPickerController/include/CTAssetThumbnailView.h
+++ b/CTAssetsPickerController/include/CTAssetThumbnailView.h
@@ -1,0 +1,1 @@
+../CTAssetThumbnailView.h

--- a/CTAssetsPickerController/include/CTAssetsGridSelectedView.h
+++ b/CTAssetsPickerController/include/CTAssetsGridSelectedView.h
@@ -1,0 +1,1 @@
+../CTAssetsGridSelectedView.h

--- a/CTAssetsPickerController/include/CTAssetsGridView.h
+++ b/CTAssetsPickerController/include/CTAssetsGridView.h
@@ -1,0 +1,1 @@
+../CTAssetsGridView.h

--- a/CTAssetsPickerController/include/CTAssetsGridViewCell.h
+++ b/CTAssetsPickerController/include/CTAssetsGridViewCell.h
@@ -1,0 +1,1 @@
+../CTAssetsGridViewCell.h

--- a/CTAssetsPickerController/include/CTAssetsGridViewController.h
+++ b/CTAssetsPickerController/include/CTAssetsGridViewController.h
@@ -1,0 +1,1 @@
+../CTAssetsGridViewController.h

--- a/CTAssetsPickerController/include/CTAssetsGridViewFooter.h
+++ b/CTAssetsPickerController/include/CTAssetsGridViewFooter.h
@@ -1,0 +1,1 @@
+../CTAssetsGridViewFooter.h

--- a/CTAssetsPickerController/include/CTAssetsGridViewLayout.h
+++ b/CTAssetsPickerController/include/CTAssetsGridViewLayout.h
@@ -1,0 +1,1 @@
+../CTAssetsGridViewLayout.h

--- a/CTAssetsPickerController/include/CTAssetsNavigationController.h
+++ b/CTAssetsPickerController/include/CTAssetsNavigationController.h
@@ -1,0 +1,1 @@
+../CTAssetsNavigationController.h

--- a/CTAssetsPickerController/include/CTAssetsPageView.h
+++ b/CTAssetsPickerController/include/CTAssetsPageView.h
@@ -1,0 +1,1 @@
+../CTAssetsPageView.h

--- a/CTAssetsPickerController/include/CTAssetsPageViewController+Internal.h
+++ b/CTAssetsPickerController/include/CTAssetsPageViewController+Internal.h
@@ -1,0 +1,1 @@
+../CTAssetsPageViewController+Internal.h

--- a/CTAssetsPickerController/include/CTAssetsPageViewController.h
+++ b/CTAssetsPickerController/include/CTAssetsPageViewController.h
@@ -1,0 +1,1 @@
+../CTAssetsPageViewController.h

--- a/CTAssetsPickerController/include/CTAssetsPickerAccessDeniedView.h
+++ b/CTAssetsPickerController/include/CTAssetsPickerAccessDeniedView.h
@@ -1,0 +1,1 @@
+../CTAssetsPickerAccessDeniedView.h

--- a/CTAssetsPickerController/include/CTAssetsPickerController+Internal.h
+++ b/CTAssetsPickerController/include/CTAssetsPickerController+Internal.h
@@ -1,0 +1,1 @@
+../CTAssetsPickerController+Internal.h

--- a/CTAssetsPickerController/include/CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../CTAssetsPickerController.h

--- a/CTAssetsPickerController/include/CTAssetsPickerDefines.h
+++ b/CTAssetsPickerController/include/CTAssetsPickerDefines.h
@@ -1,0 +1,1 @@
+../CTAssetsPickerDefines.h

--- a/CTAssetsPickerController/include/CTAssetsPickerNoAssetsView.h
+++ b/CTAssetsPickerController/include/CTAssetsPickerNoAssetsView.h
@@ -1,0 +1,1 @@
+../CTAssetsPickerNoAssetsView.h

--- a/CTAssetsPickerController/include/CTAssetsViewControllerTransition.h
+++ b/CTAssetsPickerController/include/CTAssetsViewControllerTransition.h
@@ -1,0 +1,1 @@
+../CTAssetsViewControllerTransition.h

--- a/CTAssetsPickerController/include/NSBundle+CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/NSBundle+CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../NSBundle+CTAssetsPickerController.h

--- a/CTAssetsPickerController/include/NSDateFormatter+CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/NSDateFormatter+CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../NSDateFormatter+CTAssetsPickerController.h

--- a/CTAssetsPickerController/include/NSIndexSet+CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/NSIndexSet+CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../NSIndexSet+CTAssetsPickerController.h

--- a/CTAssetsPickerController/include/NSNumberFormatter+CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/NSNumberFormatter+CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../NSNumberFormatter+CTAssetsPickerController.h

--- a/CTAssetsPickerController/include/PHAsset+CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/PHAsset+CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../PHAsset+CTAssetsPickerController.h

--- a/CTAssetsPickerController/include/PHAssetCollection+CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/PHAssetCollection+CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../PHAssetCollection+CTAssetsPickerController.h

--- a/CTAssetsPickerController/include/PHImageManager+CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/PHImageManager+CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../PHImageManager+CTAssetsPickerController.h

--- a/CTAssetsPickerController/include/UICollectionView+CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/UICollectionView+CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../UICollectionView+CTAssetsPickerController.h

--- a/CTAssetsPickerController/include/UIImage+CTAssetsPickerController.h
+++ b/CTAssetsPickerController/include/UIImage+CTAssetsPickerController.h
@@ -1,0 +1,1 @@
+../UIImage+CTAssetsPickerController.h

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,7 @@ let package = Package(
     targets: [
         .target(name: "CTAssetsPickerController",
                 dependencies: ["PureLayout"],
-                path: "CTAssetsPickerController",
-                publicHeadersPath: "")
+                path: "CTAssetsPickerController")
     ]
 )
 


### PR DESCRIPTION
Also update to use the `SWIFTPM_MODULE_BUNDLE` macro to fix the issue with missing images in Agent Tools.