### PR TITLE
IOS-4154: Add cancel button title property

### DIFF
--- a/CTAssetsPickerController/CTAssetCollectionViewController.m
+++ b/CTAssetsPickerController/CTAssetCollectionViewController.m
@@ -372,10 +372,8 @@
 
 - (void)resetTitle
 {
-    if (!self.picker.title)
-        self.title = CTAssetsPickerLocalizedString(@"Photos", nil);
-    else
-        self.title = self.picker.title;
+    self.title = self.picker.title ?: CTAssetsPickerLocalizedString(@"Photos", nil);
+    self.navigationItem.backButtonTitle = self.picker.navigationItem.backButtonTitle ?: self.title;
 }
 
 

--- a/CTAssetsPickerController/CTAssetCollectionViewController.m
+++ b/CTAssetsPickerController/CTAssetCollectionViewController.m
@@ -153,15 +153,16 @@
         
         self.doneButton =
         [[UIBarButtonItem alloc] initWithTitle:title
-                                         style:UIBarButtonItemStyleDone
+                                         style:UIBarButtonItemStylePlain
                                         target:self.picker
                                         action:@selector(finishPickingAssets:)];
     }
     
     if (self.cancelButton == nil)
     {
+        NSString *title = self.picker.cancelButtonTitle ?: CTAssetsPickerLocalizedString(@"Cancel", nil);
         self.cancelButton =
-        [[UIBarButtonItem alloc] initWithTitle:CTAssetsPickerLocalizedString(@"Cancel", nil)
+        [[UIBarButtonItem alloc] initWithTitle:title
                                          style:UIBarButtonItemStylePlain
                                         target:self.picker
                                         action:@selector(dismiss:)];

--- a/CTAssetsPickerController/CTAssetsGridViewController.m
+++ b/CTAssetsPickerController/CTAssetsGridViewController.m
@@ -184,7 +184,7 @@ NSString * const CTAssetsGridViewFooterIdentifier = @"CTAssetsGridViewFooterIden
         
         self.navigationItem.rightBarButtonItem =
         [[UIBarButtonItem alloc] initWithTitle:title
-                                         style:UIBarButtonItemStyleDone
+                                         style:UIBarButtonItemStylePlain
                                         target:self.picker
                                         action:@selector(finishPickingAssets:)];
     }

--- a/CTAssetsPickerController/CTAssetsPickerController.h
+++ b/CTAssetsPickerController/CTAssetsPickerController.h
@@ -94,6 +94,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *doneButtonTitle;
 
 /**
+ *  An optional title for the cancel button
+ *
+ *  You can override the title of "Cancel" button by this value.
+ */
+@property (nonatomic, copy) NSString *cancelButtonTitle;
+
+/**
  *  Determines whether or not the cancel button is visible in the picker.
  *
  *  The cancel button is visible by default. To hide the cancel button, (e.g. presenting the picker in `UIPopoverController`)

--- a/CTAssetsPickerController/CTAssetsPickerController.m
+++ b/CTAssetsPickerController/CTAssetsPickerController.m
@@ -351,8 +351,9 @@ NSString * const CTAssetsPickerDidDeselectAssetNotification = @"CTAssetsPickerDi
 {
     if (self.showsCancelButton)
     {
+        NSString *title = self.cancelButtonTitle ?: CTAssetsPickerLocalizedString(@"Cancel", nil);
         viewController.navigationItem.leftBarButtonItem =
-        [[UIBarButtonItem alloc] initWithTitle:CTAssetsPickerLocalizedString(@"Cancel", nil)
+        [[UIBarButtonItem alloc] initWithTitle:title
                                          style:UIBarButtonItemStylePlain
                                         target:self
                                         action:@selector(dismiss:)];


### PR DESCRIPTION
Adding a new property so that we can make the button title uppercase `CANCEL` instead of `Cancel`.